### PR TITLE
fix: preserve NA supplier names

### DIFF
--- a/tap_tilroy/client.py
+++ b/tap_tilroy/client.py
@@ -190,6 +190,17 @@ class TilroyStream(RESTStream[int]):
         "idTilroy", "idTenant", "idSource",  # Transfer API field names
     })
 
+    # Fields where literal null-like strings are valid business values.
+    _preserve_null_like_string_fields: frozenset[str] = frozenset()
+
+    def _is_null_like_string(self, key: str, value: object) -> bool:
+        """Return whether a string value should be normalized to null."""
+        return (
+            isinstance(value, str)
+            and key not in self._preserve_null_like_string_fields
+            and value.upper() in ("NA", "N/A", "NULL", "NONE", "")
+        )
+
     def post_process(
         self,
         row: dict,
@@ -214,7 +225,7 @@ class TilroyStream(RESTStream[int]):
                 continue
 
             # Handle NA string values
-            if isinstance(value, str) and value.upper() in ("NA", "N/A", "NULL", "NONE", ""):
+            if self._is_null_like_string(key, value):
                 row[key] = None
                 continue
 

--- a/tap_tilroy/streams/products.py
+++ b/tap_tilroy/streams/products.py
@@ -513,6 +513,7 @@ class SuppliersStream(TilroyStream):
     replication_method = "FULL_TABLE"
     records_jsonpath = "$[*]"
     default_count = 10000  # Suppliers are typically few, fetch all at once
+    _preserve_null_like_string_fields = frozenset({"code", "name"})
 
     schema = th.PropertiesList(
         th.Property("tilroyId", th.IntegerType),


### PR DESCRIPTION
## Summary
- keep literal `"NA"` values for Tilroy supplier `name` and `code` fields
- preserve the existing null-like string normalization for other streams/fields

## Context
IN-4485 / tenant 1384: Tilroy has an active supplier named `NA`. Source validation showed that supplier also has `code = "NA"`; both are valid supplier identity fields and must survive tap post-processing.

## Test plan
- Direct read-only Tilroy suppliers probe for tenant 1384: 147 suppliers, one `name = "NA"` with `tilroyId = 152513`; local patched `SuppliersStream.post_process` keeps both `name` and `code` as `"NA"`
- `uv run python -m compileall tap_tilroy`
- `git diff --check`

Note: no test files included per reviewer preference.