### PR TITLE
Fix Tilroy supplier code and PO modified incrementals

### DIFF
--- a/tap_tilroy/streams/products.py
+++ b/tap_tilroy/streams/products.py
@@ -517,6 +517,8 @@ class SuppliersStream(TilroyStream):
 
     schema = th.PropertiesList(
         th.Property("tilroyId", th.IntegerType),
-        th.Property("code", th.CustomType({"type": ["string", "number", "null"]})),
-        th.Property("name", th.CustomType({"type": ["string", "number", "null"]})),
+        # Supplier codes are identifiers, not numeric values. Keep them as strings
+        # so leading zeroes from Tilroy (for example "00560") survive CSV output.
+        th.Property("code", th.CustomType({"type": ["string", "null"]})),
+        th.Property("name", th.CustomType({"type": ["string", "null"]})),
     ).to_dict()

--- a/tap_tilroy/streams/purchase.py
+++ b/tap_tilroy/streams/purchase.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import typing as t
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 
 from singer_sdk import typing as th
 
 from tap_tilroy.client import TilroyStream
+
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
@@ -20,20 +21,22 @@ PURCHASE_ORDER_STATUSES = ["draft", "open", "delivered", "cancelled", "backorder
 class PurchaseOrdersStream(TilroyStream):
     """Stream for Tilroy purchase orders.
 
-    Always uses /purchaseorders endpoint with orderDateFrom + orderDateTo.
-    Iterates through warehouse_id + status combinations internally to avoid
-    per-partition state bloat. Maintains a single global bookmark.
-    
+    The Tilroy purchase-orders endpoint exposes modified timestamps on records,
+    but the live API ignores tested modified/dateModified request parameters.
+    Therefore this stream fetches the paginated purchase-order set and applies
+    the modified cursor client-side. This prevents old orders with later status
+    changes from being skipped by an orderDate bookmark.
+
     Note: warehouseNumber filter requires status filter.
     """
 
     name = "purchase_orders"
     path = "/purchaseapi/production/purchaseorders"
     primary_keys: t.ClassVar[list[str]] = ["tilroyId"]
-    replication_key = "orderDate"
+    replication_key = "modified_timestamp"
     replication_method = "INCREMENTAL"
     records_jsonpath = "$[*]"
-    default_count = 500
+    default_count = 100
 
     schema = th.PropertiesList(
         th.Property("tilroyId", th.CustomType({"type": ["string", "integer"]})),
@@ -48,6 +51,7 @@ class PurchaseOrdersStream(TilroyStream):
         th.Property("status", th.CustomType({"type": ["string", "number", "null"]})),
         th.Property("created", th.CustomType({"type": ["object", "string", "null"]})),
         th.Property("modified", th.CustomType({"type": ["object", "string", "null"]})),
+        th.Property("modified_timestamp", th.DateTimeType),
         th.Property(
             "lines",
             th.ArrayType(
@@ -87,56 +91,97 @@ class PurchaseOrdersStream(TilroyStream):
         ),
     ).to_dict()
 
+    @staticmethod
+    def _parse_timestamp(value: object) -> datetime | None:
+        """Parse a Tilroy timestamp into a comparable aware datetime."""
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, str) and value:
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        else:
+            return None
+
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def _get_stream_state(self) -> dict:
+        """Return the global stream state when available."""
+        try:
+            state = self.get_context_state(None)
+        except AttributeError:
+            state = None
+
+        if isinstance(state, dict):
+            return state
+
+        return {}
+
     def _get_start_date(self) -> datetime:
-        """Determine the start date for filtering from global bookmark.
+        """Determine the modified start date from the global bookmark.
 
-        Returns:
-            The start date for the query.
+        Legacy deployments bookmarked this stream by orderDate. That bookmark is
+        intentionally ignored once the replication key changes, otherwise old
+        orders modified after their original order date would remain skipped.
         """
-        # Try to get from bookmark (no context = global bookmark)
-        bookmark_date = self.get_starting_timestamp(None)
+        stream_state = self._get_stream_state()
+        if stream_state.get("replication_key") not in (None, self.replication_key):
+            self.logger.info(
+                "[%s] Ignoring legacy %s bookmark while switching to %s",
+                self.name,
+                stream_state.get("replication_key"),
+                self.replication_key,
+            )
+        else:
+            bookmark_date = stream_state.get("replication_key_value")
+            if not bookmark_date:
+                bookmark_date = self.get_starting_timestamp(None)
+            if bookmark_date:
+                parsed = self._parse_timestamp(bookmark_date)
+                if parsed:
+                    return parsed
 
-        if bookmark_date:
-            # Go back 1 day to avoid missing records at boundary
-            if hasattr(bookmark_date, "date"):
-                date_only = bookmark_date.date()
-            else:
-                date_only = bookmark_date
-            return datetime.combine(date_only - timedelta(days=1), datetime.min.time())
-
-        # Fall back to config start_date
         config_start = self.config.get("start_date", "2010-01-01T00:00:00Z")
-        date_part = config_start.split("T")[0]
-        return datetime.strptime(date_part, "%Y-%m-%d")
+        parsed_config = self._parse_timestamp(config_start)
+        if parsed_config:
+            return parsed_config
+
+        date_part = str(config_start).split("T")[0]
+        return datetime.strptime(date_part, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    def _get_request_params(
+        self,
+        warehouse_id: int | None,
+        status: str | None,
+        page: int,
+    ) -> dict[str, t.Any]:
+        """Build request params for the unfiltered purchase-order page.
+
+        The live API ignores modified/dateModified query params on this endpoint,
+        so incremental filtering happens after parsing records.
+        """
+        params: dict[str, t.Any] = {
+            "count": self.default_count,
+            "page": page,
+        }
+
+        if warehouse_id and status:
+            params["warehouseNumber"] = warehouse_id
+            params["status"] = status
+
+        return params
 
     def _fetch_page(
         self,
         warehouse_id: int | None,
         status: str | None,
         page: int,
-        start_date: datetime,
     ) -> tuple[list[dict], bool]:
-        """Fetch a single page of purchase orders.
-        
-        Args:
-            warehouse_id: Warehouse number filter (requires status).
-            status: Status filter (required with warehouse_id).
-            page: Page number.
-            start_date: Start date for orderDateFrom.
-            
-        Returns:
-            Tuple of (records, has_more_pages).
-        """
-        params = {
-            "count": self.default_count,
-            "page": page,
-            "orderDateFrom": start_date.strftime("%Y-%m-%d"),
-            "orderDateTo": datetime.now().strftime("%Y-%m-%d"),
-        }
-
-        if warehouse_id and status:
-            params["warehouseNumber"] = warehouse_id
-            params["status"] = status
+        """Fetch a single page of purchase orders."""
+        params = self._get_request_params(warehouse_id, status, page)
 
         prepared = self.build_prepared_request(
             method="GET",
@@ -158,58 +203,71 @@ class PurchaseOrdersStream(TilroyStream):
         self,
         warehouse_id: int | None,
         status: str | None,
-        start_date: datetime,
     ) -> t.Iterable[dict]:
         """Fetch all pages for a warehouse/status combination.
-        
+
         Args:
             warehouse_id: Warehouse number filter.
             status: Status filter.
-            start_date: Start date for filtering.
-            
+
         Yields:
             Purchase order records.
         """
         page = 1
         while True:
-            records, has_more = self._fetch_page(warehouse_id, status, page, start_date)
+            records, has_more = self._fetch_page(warehouse_id, status, page)
             
             # Break if no records returned (avoid infinite loop)
             if not records:
                 break
-            
-            for record in records:
-                yield record
-            
+            yield from records
+
             if not has_more:
                 break
             page += 1
 
     def get_records(self, context: Context | None) -> t.Iterable[dict]:
-        """Fetch purchase orders, iterating through warehouse/status combos internally.
-        
+        """Fetch purchase orders and filter records by modified timestamp.
+
         This avoids partition-based state. Single global bookmark is maintained.
         """
         start_date = self._get_start_date()
         warehouse_ids = getattr(self._tap, "_resolved_shop_ids", [])
-        
+
         if not warehouse_ids:
-            # No warehouse filter - fetch all
-            self.logger.info(f"[{self.name}] Fetching all purchase orders from {start_date.date()}")
-            yield from self._fetch_all_for_filter(None, None, start_date)
-        else:
-            # Iterate through each warehouse + status combination
             self.logger.info(
-                f"[{self.name}] Fetching for warehouses {warehouse_ids} from {start_date.date()}"
+                "[%s] Fetching all purchase orders modified since %s",
+                self.name,
+                start_date.isoformat(),
             )
-            for wh_id in warehouse_ids:
-                for status in PURCHASE_ORDER_STATUSES:
-                    yield from self._fetch_all_for_filter(wh_id, status, start_date)
+            raw_records = self._fetch_all_for_filter(None, None)
+        else:
+            self.logger.info(
+                "[%s] Fetching purchase orders for warehouses %s modified since %s",
+                self.name,
+                warehouse_ids,
+                start_date.isoformat(),
+            )
+            raw_records = (
+                record
+                for wh_id in warehouse_ids
+                for status in PURCHASE_ORDER_STATUSES
+                for record in self._fetch_all_for_filter(wh_id, status)
+            )
+
+        for record in raw_records:
+            processed = self.post_process(record, context)
+            if not processed:
+                continue
+
+            modified_at = self._parse_timestamp(processed.get(self.replication_key))
+            if modified_at and modified_at >= start_date:
+                yield processed
 
     def post_process(
         self,
         row: dict,
-        context: Context | None = None,
+        context: Context | None = None,  # noqa: ARG002
     ) -> dict | None:
         """Post-process purchase order record.
 
@@ -220,23 +278,39 @@ class PurchaseOrdersStream(TilroyStream):
 
         # Skip error responses
         if "code" in row and "message" in row:
-            self.logger.warning(f"[{self.name}] Skipping error record: {row['message']}")
+            self.logger.warning(
+                "[%s] Skipping error record: %s",
+                self.name,
+                row["message"],
+            )
             return None
 
         # Validate orderDate exists
         if not row.get("orderDate"):
-            self.logger.warning(f"[{self.name}] Skipping record without orderDate")
+            self.logger.warning("[%s] Skipping record without orderDate", self.name)
             return None
 
         # Parse orderDate string to datetime
         order_date = row["orderDate"]
-        if isinstance(order_date, str):
-            try:
-                row["orderDate"] = datetime.fromisoformat(
-                    order_date.replace("Z", "+00:00")
-                )
-            except ValueError:
-                self.logger.warning(f"[{self.name}] Invalid orderDate format: {order_date}")
-                return None
+        parsed_order_date = self._parse_timestamp(order_date)
+        if parsed_order_date:
+            row["orderDate"] = parsed_order_date
+        else:
+            self.logger.warning(
+                "[%s] Invalid orderDate format: %s",
+                self.name,
+                order_date,
+            )
+            return None
+
+        modified_at = None
+        modified = row.get("modified")
+        if isinstance(modified, dict):
+            modified_at = self._parse_timestamp(modified.get("timestamp"))
+
+        # Some historical/source records may not carry modified metadata. Keep
+        # them syncable by falling back to orderDate, while normal records use
+        # the actual modified timestamp as the incremental cursor.
+        row[self.replication_key] = modified_at or parsed_order_date
 
         return row

--- a/tests/test_purchase_orders.py
+++ b/tests/test_purchase_orders.py
@@ -1,0 +1,98 @@
+"""Tests for the Tilroy purchase-orders stream."""
+
+# ruff: noqa: S101, SLF001
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from tap_tilroy.streams.purchase import PurchaseOrdersStream
+
+
+class DummyLogger:
+    """Minimal logger for object.__new__ stream tests."""
+
+    def info(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return None
+
+    def warning(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return None
+
+
+def make_stream() -> PurchaseOrdersStream:
+    """Create a lightweight stream instance without live tap initialization."""
+    stream = object.__new__(PurchaseOrdersStream)
+    stream.logger = DummyLogger()
+    stream.name = PurchaseOrdersStream.name
+    stream.replication_key = PurchaseOrdersStream.replication_key
+    stream.default_count = PurchaseOrdersStream.default_count
+    stream._config = {"start_date": "2019-01-01T00:00:00Z"}
+    stream._tap = SimpleNamespace(_resolved_shop_ids=[])
+    return stream
+
+
+def test_request_params_do_not_use_order_date_cursor() -> None:
+    """Purchase-order requests fetch pages; modified filtering is client-side."""
+    stream = make_stream()
+
+    params = stream._get_request_params(warehouse_id=20, status="delivered", page=3)
+
+    assert params == {
+        "count": PurchaseOrdersStream.default_count,
+        "page": 3,
+        "warehouseNumber": 20,
+        "status": "delivered",
+    }
+    assert "orderDateFrom" not in params
+    assert "orderDateTo" not in params
+
+
+def test_post_process_uses_modified_timestamp_as_replication_key() -> None:
+    """Modified timestamp is exposed as a top-level Singer replication key."""
+    stream = make_stream()
+    row = {
+        "tilroyId": "6952898fd773c71239f3f755",
+        "number": "PO-179",
+        "orderDate": "2026-01-02T09:00:00.000Z",
+        "modified": {"timestamp": "2026-03-26T13:24:00.000Z"},
+    }
+
+    processed = stream.post_process(row)
+
+    assert processed is not None
+    assert processed["modified_timestamp"] == datetime(
+        2026,
+        3,
+        26,
+        13,
+        24,
+        tzinfo=timezone.utc,
+    )
+    assert processed["orderDate"] == datetime(2026, 1, 2, 9, 0, tzinfo=timezone.utc)
+
+
+def test_get_records_filters_by_modified_timestamp() -> None:
+    """Old order dates still emit when the modified timestamp is inside state."""
+    stream = make_stream()
+    stream._get_start_date = lambda: datetime(2026, 3, 1, tzinfo=timezone.utc)  # type: ignore[method-assign]
+    stream._fetch_all_for_filter = lambda _warehouse_id, _status: iter(  # type: ignore[method-assign]
+        [
+            {
+                "tilroyId": "old-change",
+                "number": "PO-179",
+                "orderDate": "2026-01-02T09:00:00.000Z",
+                "modified": {"timestamp": "2026-03-26T13:24:00.000Z"},
+            },
+            {
+                "tilroyId": "too-old",
+                "number": "PO-1",
+                "orderDate": "2026-01-01T09:00:00.000Z",
+                "modified": {"timestamp": "2026-02-01T13:24:00.000Z"},
+            },
+        ]
+    )
+
+    records = list(stream.get_records(None))
+
+    assert [record["number"] for record in records] == ["PO-179"]


### PR DESCRIPTION
## Summary
- Preserve Tilroy supplier codes as strings (existing PR change)
- Switch purchase_orders replication from orderDate to a top-level modified_timestamp derived from modified.timestamp
- Stop sending orderDateFrom/orderDateTo for purchase_orders; live Tilroy ignores tested modified/dateModified query params, so the tap fetches pages and filters client-side by modified timestamp
- Ignore legacy orderDate bookmarks once when moving to modified_timestamp, so older POs with later delivery/status changes are picked up
- Lower purchase_orders page size to 100; live unfiltered count=500 returned Tilroy 500s while count=100 succeeded

## Verification
- Live API probe on tenant 1384: modified/dateModified request params on /purchaseorders were ignored; orderDate range 2026-01-01..03 contained PO-179 with modified 2026-03-26
- Live stream smoke with modified state 2026-03-26 returned 101 records and included PO-179
- uv run pytest tests/test_purchase_orders.py
- uvx ruff check tap_tilroy/streams/purchase.py tests/test_purchase_orders.py --select F,E9
- uv run tap-tilroy --config <temp> --discover confirmed purchase_orders replication_key=modified_timestamp
